### PR TITLE
Reuse MetricName objects because they are expensive to make.

### DIFF
--- a/contrib/pinot-druid-benchmark/src/main/java/org/apache/pinotdruidbenchmark/PinotThroughput.java
+++ b/contrib/pinot-druid-benchmark/src/main/java/org/apache/pinotdruidbenchmark/PinotThroughput.java
@@ -33,7 +33,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-
+import org.apache.http.util.EntityUtils;
 
 /**
  * Test throughput for Pinot.
@@ -90,8 +90,9 @@ public class PinotThroughput {
           try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             while (System.currentTimeMillis() < endTime) {
               long startTime = System.currentTimeMillis();
-              CloseableHttpResponse httpResponse = httpClient.execute(httpPosts[RANDOM.nextInt(numQueries)]);
-              httpResponse.close();
+              try (CloseableHttpResponse httpResponse = httpClient.execute(httpPosts[RANDOM.nextInt(numQueries)])) {
+                EntityUtils.consume(httpResponse.getEntity());
+              }
               long responseTime = System.currentTimeMillis() - startTime;
               counter.getAndIncrement();
               totalResponseTime.getAndAdd(responseTime);

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -248,6 +248,11 @@
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>2.8.0</version>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/MetricsHelperTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/MetricsHelperTest.java
@@ -18,15 +18,19 @@
  */
 package org.apache.pinot.common.metrics;
 
-import com.yammer.metrics.core.MetricName;
-import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.*;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.MapConfiguration;
 import org.testng.annotations.Test;
 
+import static junit.framework.Assert.assertNotNull;
+import static org.apache.pinot.common.utils.CommonConstants.Server.DEFAULT_METRICS_PREFIX;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 
@@ -73,5 +77,80 @@ public class MetricsHelperTest {
     // Check that the two listeners fired
     assertTrue(listenerOneOkay);
     assertTrue(listenerTwoOkay);
+  }
+
+  @Test
+  public void testMetricNameGetHelper() {
+    final String METRIC_NAME = "dummy";
+
+    MetricName newlyAllocated = new MetricName(ServerMetrics.class, METRIC_NAME);
+    AbstractMetrics metrics = new ServerMetrics(new MetricsRegistry());
+    MetricName fromHelper = metrics.getMetricName(METRIC_NAME);
+    // Direct metrics creation must match what the helper does
+    assertEquals(fromHelper, newlyAllocated);
+    // Make sure we have a different object here, we only used the helper once
+    assertTrue(newlyAllocated != fromHelper);
+    MetricName fromHelperCached = metrics.getMetricName(METRIC_NAME);
+    // Identity test has to work because we are caching the names
+    assertTrue(fromHelper == fromHelperCached);
+  }
+
+  @Test
+  public void testMetricsApisTiming() {
+    final String TABLE_NAME = "customers";
+
+    MetricsRegistry registry = new MetricsRegistry();
+    AbstractMetrics metrics = new ServerMetrics(registry);
+
+    metrics.addPhaseTiming(TABLE_NAME, BrokerQueryPhase.QUERY_EXECUTION, 10);
+    metrics.addPhaseTiming(TABLE_NAME, BrokerQueryPhase.QUERY_EXECUTION, 15);
+
+    Map<MetricName, Metric> allMetrics = registry.allMetrics();
+    assertTrue(allMetrics.size() == 1);
+    Timer timer = (Timer)allMetrics.values().iterator().next();
+    // The sum should be the two query executions added together
+    assertEquals(timer.sum(), 25.0/1_000_000);
+  }
+
+  @Test
+  public void testMetricsApisMeteredTableValues() {
+    final String TABLE_NAME = "customers";
+
+    MetricsRegistry registry = new MetricsRegistry();
+    AbstractMetrics metrics = new ServerMetrics(registry);
+
+    metrics.addMeteredTableValue(TABLE_NAME, ServerMeter.NUM_SEGMENTS_MATCHED, 10);
+    Meter meter = metrics.getMeteredTableValue(TABLE_NAME, ServerMeter.NUM_SEGMENTS_MATCHED);
+
+    assertNotNull(meter);
+  }
+
+  @Test
+  public void testMetricsApisMeteredQueryValues() {
+    final String TABLE_NAME = "customers";
+
+    MetricsRegistry registry = new MetricsRegistry();
+    AbstractMetrics metrics = new ServerMetrics(registry);
+
+    metrics.addMeteredQueryValue(null, ServerMeter.NUM_SEGMENTS_MATCHED, 10);
+
+    Map<MetricName, Metric> allMetrics = registry.allMetrics();
+    assertTrue(allMetrics.size() == 1);
+  }
+
+  @Test
+  public void testMetricsCallBackGauge() {
+    final String METRIC_NAME = "test";
+
+    MetricsRegistry registry = new MetricsRegistry();
+    AbstractMetrics metrics = new ServerMetrics(registry);
+
+    metrics.addCallbackGauge(METRIC_NAME, () -> ServerGauge.DOCUMENT_COUNT);
+
+    Map<MetricName, Metric> allMetrics = registry.allMetrics();
+    assertTrue(allMetrics.size() == 1);
+    MetricName fromHelper = metrics.getMetricName(DEFAULT_METRICS_PREFIX + METRIC_NAME);
+    // Identity test has to work because we are caching the names
+    assertTrue(fromHelper == allMetrics.keySet().iterator().next());
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -259,7 +259,7 @@ public class PinotHelixResourceManager {
   private void addInstanceGroupTagIfNeeded() {
     InstanceConfig instanceConfig = getHelixInstanceConfig(_instanceId);
     assert instanceConfig != null;
-    if (!instanceConfig.containsTag(Helix.CONTROLLER_INSTANCE)) {
+    if (instanceConfig != null && !instanceConfig.containsTag(Helix.CONTROLLER_INSTANCE)) {
       LOGGER.info("Controller: {} doesn't contain group tag: {}. Adding one.", _instanceId, Helix.CONTROLLER_INSTANCE);
       instanceConfig.addTag(Helix.CONTROLLER_INSTANCE);
       HelixDataAccessor accessor = _helixZkManager.getHelixDataAccessor();


### PR DESCRIPTION
The following change removes the MetricName object allocation that would happen on any metering or timing call to the AbstractMetrics. The object allocation rate can get up to multiple GBs/sec, if Pinot can push a QPS of 2000 queries/sec or more. There's an additional locking cost of creating the MetricNames objects because the underlying yammer Metrics object that's created uses the JDK getClassName method call, which does a synchronized lock on the class loader object, effectively creating a false contention problem.

The metrics allocation and contention issue is resolved by using a capped cache of 1000 MetricNames using the high performance Caffeine cache class. It's important to use capped collection here to avoid memory leaks in case there's a bug in the Metric naming.

Tested various LRU cache implementations with this quick benchmarks we made here:

Results are as follows (4 core/ 8 thread Linux JDK8):

Running with 8 worker threads (lower is better)...
Timing Guava cache ...
Elapsed time 42205ms
Timing Map cache ...
Elapsed time 22649ms
Timing Caffeine cache ...
Elapsed time 11888ms

Running with 16 worker threads (lower is better)...
Timing Guava cache ...
Elapsed time 90137ms
Timing Map cache ...
Elapsed time 34901ms
Timing Caffeine cache ...
Elapsed time 27998ms

Caffeine as implementation is equal or better than plain old ConcurrentHashMap, seems most suitable for using it as LRU cache.

Todo: 
- [x] Find good initial concurrency parameters
- [x] Benchmark the individual improvement and produce numbers
- [x] Add tests for MetricName caching


Performance measurement results:
Machine configuration:
4 core (8 threads) Intel(R) Xeon(R) W-2123 CPU @ 3.60GHz
32GB of RAM
Linux x86-64, kernel: 5.0.0-37-generic

Benchmark configuration:
TPC-H (optimal index)
20 clients
180s runtime

Results (QPS higher is better, response time lower is better)

Base with (fix-benchmark-client):
Time Passed: 180.014s, Query Executed: 513267, QPS: 2851.2615685446685, Avg Response Time: 7.001299518574154ms
Improved (this branch):
Time Passed: 180.014s, Query Executed: 528540, QPS: 2936.104969613474, Avg Response Time: 6.800626253452908ms

Co-authored-by: @grcevski @charliegracie @macarte @adityamandaleeka