### PR TITLE
Fix benchmark client

### DIFF
--- a/contrib/pinot-druid-benchmark/src/main/java/org/apache/pinotdruidbenchmark/PinotThroughput.java
+++ b/contrib/pinot-druid-benchmark/src/main/java/org/apache/pinotdruidbenchmark/PinotThroughput.java
@@ -33,7 +33,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-
+import org.apache.http.util.EntityUtils;
 
 /**
  * Test throughput for Pinot.
@@ -90,8 +90,9 @@ public class PinotThroughput {
           try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             while (System.currentTimeMillis() < endTime) {
               long startTime = System.currentTimeMillis();
-              CloseableHttpResponse httpResponse = httpClient.execute(httpPosts[RANDOM.nextInt(numQueries)]);
-              httpResponse.close();
+              try (CloseableHttpResponse httpResponse = httpClient.execute(httpPosts[RANDOM.nextInt(numQueries)])) {
+                EntityUtils.consume(httpResponse.getEntity());
+              }
               long responseTime = System.currentTimeMillis() - startTime;
               counter.getAndIncrement();
               totalResponseTime.getAndAdd(responseTime);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -263,7 +263,7 @@ public class PinotHelixResourceManager {
    */
   private void addInstanceGroupTagIfNeeded() {
     InstanceConfig instanceConfig = getHelixInstanceConfig(_instanceId);
-    assert instanceConfig != null;
+    // The instanceConfig can be null when connecting as a participant while running from PerfBenchmarkRunner
     if (instanceConfig != null && !instanceConfig.containsTag(Helix.CONTROLLER_INSTANCE)) {
       LOGGER.info("Controller: {} doesn't contain group tag: {}. Adding one.", _instanceId, Helix.CONTROLLER_INSTANCE);
       instanceConfig.addTag(Helix.CONTROLLER_INSTANCE);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -264,7 +264,7 @@ public class PinotHelixResourceManager {
   private void addInstanceGroupTagIfNeeded() {
     InstanceConfig instanceConfig = getHelixInstanceConfig(_instanceId);
     assert instanceConfig != null;
-    if (!instanceConfig.containsTag(Helix.CONTROLLER_INSTANCE)) {
+    if (instanceConfig != null && !instanceConfig.containsTag(Helix.CONTROLLER_INSTANCE)) {
       LOGGER.info("Controller: {} doesn't contain group tag: {}. Adding one.", _instanceId, Helix.CONTROLLER_INSTANCE);
       instanceConfig.addTag(Helix.CONTROLLER_INSTANCE);
       HelixDataAccessor accessor = _helixZkManager.getHelixDataAccessor();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -238,7 +238,7 @@ public class PerfBenchmarkDriver {
     if (_segmentFormatVersion != null) {
       serverConfiguration.setProperty(CommonConstants.Server.CONFIG_OF_SEGMENT_FORMAT_VERSION, _segmentFormatVersion);
     }
-    serverConfiguration.setProperty(CommonConstants.Helix.Instance.INSTANCE_ID_KEY, _serverInstanceName);
+    serverConfiguration.setProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_ID, _serverInstanceName);
     LOGGER.info("Starting server instance: {}", _serverInstanceName);
     new HelixServerStarter(_clusterName, _zkAddress, serverConfiguration);
   }


### PR DESCRIPTION
There's a bug in the PinotThroughput benchmark client, where if an exception happens while running a http request to the Pinot benchmark cluster, the driver will not close the connection and eventually we'll run out of socket handles. This bug seems to affect MacOS and Windows only.
The fix simply moves the httpRequest into a try region and consumes the response to simulate more accurate workload.

The benchmark cluster also seems to fail to start because of a NullPointerException in PinotHelixResourceManager. There's probably a better fix here, we'll need some help to do it properly. For now, so we can make progress we simply checked against the nullness of the instanceConfig.

Co-authored-by: @grcevski @charliegracie @macarte @adityamandaleeka
 