### PR TITLE
Reuse temporary bytebuffer in loop

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
@@ -387,23 +387,27 @@ public class ObjectSerDeUtils {
       if (size == 0) {
         return map;
       }
+      ByteBuffer temp = byteBuffer.duplicate();
 
       // De-serialize each key-value pair
       int keyTypeValue = byteBuffer.getInt();
       int valueTypeValue = byteBuffer.getInt();
       for (int i = 0; i < size; i++) {
-        Object key = ObjectSerDeUtils.deserialize(sliceByteBuffer(byteBuffer, byteBuffer.getInt()), keyTypeValue);
-        Object value = ObjectSerDeUtils.deserialize(sliceByteBuffer(byteBuffer, byteBuffer.getInt()), valueTypeValue);
+        Object key = ObjectSerDeUtils.deserialize(slideByteBuffer(byteBuffer, temp, byteBuffer.getInt()), keyTypeValue);
+        Object value = ObjectSerDeUtils.deserialize(slideByteBuffer(byteBuffer, temp, byteBuffer.getInt()), valueTypeValue);
         map.put(key, value);
       }
       return map;
     }
 
-    private ByteBuffer sliceByteBuffer(ByteBuffer byteBuffer, int size) {
-      ByteBuffer slice = byteBuffer.slice();
-      slice.limit(size);
-      byteBuffer.position(byteBuffer.position() + size);
-      return slice;
+    private ByteBuffer slideByteBuffer(ByteBuffer byteBuffer, ByteBuffer temp, int size) {
+      int head = byteBuffer.position();
+      int tail = head + size;
+      temp.limit(tail);
+      temp.position(head);
+      byteBuffer.position(tail);
+
+      return temp;
     }
   };
 


### PR DESCRIPTION
This is a small change that removes an object allocation in a common loop where we deserialize Maps in Pinot. It works by creating one secondary temporary buffer and then we adjust the buffer start and end, instead of making new buffer each time.

Performance measurement results:

Machine configuration:
4 core (8 threads) Intel(R) Xeon(R) W-2123 CPU @ 3.60GHz
32GB of RAM
Linux x86-64, kernel: 5.0.0-37-generic

Benchmark configuration:
TPC-H (optimal index)
20 clients
180s runtime

Results (QPS higher is better, response time lower is better)

Base with (parse-query-cache):
Time Passed: 180.014s, Query Executed: 546726, QPS: 3037.1304454098013, Avg Response Time: 6.5738871024974115ms

Improved (this branch):
Time Passed: 180.013s, Query Executed: 567074, QPS: 3150.1835978512663, Avg Response Time: 6.337580280527762ms

Todo:
- [x] Run unit tests

Co-authored-by: @grcevski @charliegracie @macarte @adityamandaleeka