### PR TITLE
Refactor results trimming to avoid rebuilding the maps.

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java
@@ -61,7 +61,7 @@ import org.testng.annotations.BeforeTest;
  * </ul>
  */
 public abstract class BaseMultiValueQueriesTest extends BaseQueriesTest {
-  private static final String AVRO_DATA = "data" + File.separator + "test_data-mv.avro";
+  private static final String AVRO_DATA = "data/test_data-mv.avro";
   private static final String SEGMENT_NAME = "testTable_1756015683_1756015683";
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "MultiValueQueriesTest");
 


### PR DESCRIPTION
One of the hottest parts of the code which is doing the GroupBy operation is needlessly recreating a HashMap in the most common case. This change flips the data structure for intermediate results around to take advantage of more optimal results trimming. If the results don't have to be trimmed the original produced Map is simply returned back.

Todo: 
- [X] Benchmark the individual improvement and produce numbers
- [x] Run/Add tests results trimming


Performance measurement results:
Machine configuration:
4 core (8 threads) Intel(R) Xeon(R) W-2123 CPU @ 3.60GHz
32GB of RAM
Linux x86-64, kernel: 5.0.0-37-generic

Benchmark configuration:
TPC-H (optimal index)
20 clients
180s runtime

Results (QPS higher is better, response time lower is better)

Base with (resuse-bytebuffer):
180.013s, Query Executed: 567074, QPS: 3150.1835978512663, Avg Response Time: 6.337580280527762ms

Improved (this branch):
Time Passed: 180.013s, Query Executed: 617034, QPS: 3427.7191091754485, Avg Response Time: 5.82426738234846ms

Co-authored-by: @grcevski @charliegracie @macarte @adityamandaleeka