### PR TITLE
Reuse bytebuffer when possible

### DIFF
--- a/contrib/pinot-druid-benchmark/src/main/java/org/apache/pinotdruidbenchmark/PinotThroughput.java
+++ b/contrib/pinot-druid-benchmark/src/main/java/org/apache/pinotdruidbenchmark/PinotThroughput.java
@@ -33,7 +33,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-
+import org.apache.http.util.EntityUtils;
 
 /**
  * Test throughput for Pinot.
@@ -90,8 +90,9 @@ public class PinotThroughput {
           try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             while (System.currentTimeMillis() < endTime) {
               long startTime = System.currentTimeMillis();
-              CloseableHttpResponse httpResponse = httpClient.execute(httpPosts[RANDOM.nextInt(numQueries)]);
-              httpResponse.close();
+              try (CloseableHttpResponse httpResponse = httpClient.execute(httpPosts[RANDOM.nextInt(numQueries)])) {
+                EntityUtils.consume(httpResponse.getEntity());
+              }
               long responseTime = System.currentTimeMillis() - startTime;
               counter.getAndIncrement();
               totalResponseTime.getAndAdd(responseTime);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -259,7 +259,7 @@ public class PinotHelixResourceManager {
   private void addInstanceGroupTagIfNeeded() {
     InstanceConfig instanceConfig = getHelixInstanceConfig(_instanceId);
     assert instanceConfig != null;
-    if (!instanceConfig.containsTag(Helix.CONTROLLER_INSTANCE)) {
+    if (instanceConfig != null && !instanceConfig.containsTag(Helix.CONTROLLER_INSTANCE)) {
       LOGGER.info("Controller: {} doesn't contain group tag: {}. Adding one.", _instanceId, Helix.CONTROLLER_INSTANCE);
       instanceConfig.addTag(Helix.CONTROLLER_INSTANCE);
       HelixDataAccessor accessor = _helixZkManager.getHelixDataAccessor();

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
@@ -140,6 +140,9 @@ public class ObjectSerDeUtils {
 
     @Override
     public String deserialize(ByteBuffer byteBuffer) {
+      if (byteBuffer.hasArray()) {
+        return StringUtil.decodeUtf8(byteBuffer.array(), byteBuffer.position() + byteBuffer.arrayOffset(), byteBuffer.remaining());
+      }
       byte[] bytes = new byte[byteBuffer.remaining()];
       byteBuffer.get(bytes);
       return StringUtil.decodeUtf8(bytes);


### PR DESCRIPTION
Improve performance by re-using ByteByffer array

During String deserialization the ByteBuffer array() can be resused
instead of creating a new byte[] and reading the data from the
ByteBuffer. If the ByteBuffer is not backed by an array creating
a new byte[] and reading the data is still required.

Performance measurement results:

Machine configuration:
4 core (8 threads) Intel(R) Xeon(R) W-2123 CPU @ 3.60GHz
32GB of RAM
Linux x86-64, kernel: 5.0.0-37-generic

Benchmark configuration:
TPC-H (optimal index)
20 clients
180s runtime

Results (QPS higher is better, response time lower is better)

Base with (trimming-results-refactor):
Time Passed: 180.013s, Query Executed: 617034, QPS: 3427.7191091754485, Avg Response Time: 5.82426738234846ms

Improved (this branch):
Time Passed: 180.012s, Query Executed: 633469, QPS: 3519.0376197142414, Avg Response Time: 5.674053505380689ms

Co-authored-by: @grcevski @charliegracie @macarte @adityamandaleeka